### PR TITLE
Feature: Setup/Teardown groupings for Before/After hooks

### DIFF
--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -1,0 +1,18 @@
+Feature: Setup/Teardown hooks
+
+	Background:
+		Given passing background given
+		When passing background when
+		Then passing background then
+
+	@Named
+	Scenario: Passing test 1
+		Given passing given
+		When passing when
+		Then passing then
+
+	@Unnamed
+	Scenario: Passing test 2
+		Given passing given
+		When passing when
+		Then passing then

--- a/features/step_definitions/SetupTeardown.ts
+++ b/features/step_definitions/SetupTeardown.ts
@@ -1,0 +1,15 @@
+/* eslint-disable new-cap */
+import { defineSupportCode } from "cucumber";
+
+
+defineSupportCode(function(steps) {
+	const named = { "tags": "@Named" };
+	steps.After(named, function setupTestCase() {});
+
+	steps.Before(named, function teardownTestCase() {});
+
+	const unnamed = { "tags": "@Unnamed" };
+	steps.After(unnamed, function() {});
+
+	steps.Before(unnamed, function() {});
+});

--- a/features/step_definitions/SetupTeardown.ts
+++ b/features/step_definitions/SetupTeardown.ts
@@ -4,12 +4,12 @@ import { defineSupportCode } from "cucumber";
 
 defineSupportCode(function(steps) {
 	const named = { "tags": "@Named" };
-	steps.After(named, function setupTestCase() {});
+	steps.Before(named, function setupTestCase() {});
 
-	steps.Before(named, function teardownTestCase() {});
+	steps.After(named, function teardownTestCase() {});
 
 	const unnamed = { "tags": "@Unnamed" };
-	steps.After(unnamed, function() {});
-
 	steps.Before(unnamed, function() {});
+
+	steps.After(unnamed, function() {});
 });

--- a/src/CucumberJSAllureReporter.ts
+++ b/src/CucumberJSAllureReporter.ts
@@ -129,8 +129,6 @@ export class CucumberJSAllureFormatter extends Formatter {
 		const test = feature.caseMap === undefined ? undefined : feature.caseMap.get(data.sourceLocation!.line);
 		if (test === undefined) throw new Error("Unknown scenario");
 
-		console.log(`Test case started: ${test.name} (${test.description})`);
-
 		this.currentGroup = this.allureRuntime.startGroup("");
 		this.currentTest = this.currentGroup.startTest(this.applyExample(test.name || "Unnamed test", test.example));
 
@@ -200,7 +198,6 @@ export class CucumberJSAllureFormatter extends Formatter {
 
 		const stepText = this.applyExample(`${step.keyword}${step.text}`, test.example);
 
-		console.log(stepText);
 		if (step.isBackground) {
 			if (this.currentBefore === null) this.currentBefore = this.currentGroup!.addBefore();
 		} else {

--- a/src/CucumberJSAllureReporter.ts
+++ b/src/CucumberJSAllureReporter.ts
@@ -215,7 +215,7 @@ export class CucumberJSAllureFormatter extends Formatter {
 		}
 		if (step === undefined) throw new Error("Unknown step");
 
-		const stepText = this.applyExample(`${step.keyword}${step.text}`, test.example);
+		let stepText = this.applyExample(`${step.keyword}${step.text}`, test.example);
 
 		const isAfter = this.afterHooks.find(({ uri, line }) => {
 			if (location.actionLocation === undefined) return false;
@@ -229,10 +229,14 @@ export class CucumberJSAllureFormatter extends Formatter {
 			line === location.actionLocation!.line;
 		});
 
-		if (step.isBackground || isBefore) {
+		if (step.isBackground) {
 			if (this.currentBefore === null) this.currentBefore = this.currentGroup!.addBefore();
+		} else if (isBefore) {
+			if (this.currentBefore === null) this.currentBefore = this.currentGroup!.addBefore();
+			stepText = `Before: ${isBefore.code!.name || step.text}`;
 		} else if (isAfter) {
 			if (this.currentAfter === null) this.currentAfter = this.currentGroup!.addAfter();
+			stepText = `After: ${isAfter.code!.name || step.text}`;
 		} else {
 			if (this.currentBefore !== null) this.currentBefore = null;
 			if (this.currentAfter !== null) this.currentAfter = null;


### PR DESCRIPTION
This change represents Cucumber `Before`/`After` hooks as Setup/Teardown steps within the Allure2 report.

To do this, I add the hooks as provided by the `supportCodeLibrary` from Cucumber's `Formatter` as a property so methods can access it, then for each step I test if the `line` & `uri` can be found among either `Before` or `After` hooks.

If the step can be identified as a `Before` or `After` hook, it then tries to name it by its function name.

Example:
```typescript
Before(function initializeTestClients(scenario, callback) {
    // Do stuff
});
```

The resulting step will be named `Before: initializeTestClients`. If a function name is not available (anonymous functions), then it falls back to the existing `uri:line` representation.

I've also removed the console log. You could use `this.log` to output to console or `dummy.txt`, but using `console.log` clutters the formatter I'm outputting to `stdout` if I have this formatter outputting to a dummy file.