### PR TITLE
Fix: Trim test description to be formatted by Allure

### DIFF
--- a/features/formattedDescription.feature
+++ b/features/formattedDescription.feature
@@ -1,0 +1,48 @@
+Feature: Description is formatted
+
+    Scenario: Formatted as Markdown
+
+        This *description* **can be formatted** with markdown
+
+        ```
+        with code fencing
+        ```
+
+            or with indent code
+
+
+        Given test given
+        #comment2
+        And test given 2
+        When I do double 2
+        Then Number is 4
+
+    Scenario: Varying indent levels
+
+    Minimum indent level is used
+
+    So you can write description aligned to Scenario
+
+        indented code formatting still works fine
+
+        Given test given
+
+    Scenario: Tab indent
+
+		You can totally indent with tabs, if that's your style
+
+			the trimmer only cuts the minimum number of tabs
+
+        Given test given
+
+    Scenario: Multiple lines are joined
+
+        Same as with Markdown, multiple
+        lines are joined as one paragraph.
+        You can wrap your paragraph
+        however you'd like, and it'll be a paragraph
+
+        Until you line-break to
+        start another.
+
+        Given test given

--- a/src/CucumberJSAllureReporter.ts
+++ b/src/CucumberJSAllureReporter.ts
@@ -142,6 +142,17 @@ export class CucumberJSAllureFormatter extends Formatter {
 		this.currentAfter = null;
 	}
 
+	// remove shortest leading indentation from all lines
+	private stripIndent(data: string): string {
+		const match = data.match(/^[^\S\n]*(?=\S)/gm);
+
+		if (match !== null) {
+			const indent = Math.min(...match.map(sp => sp.length));
+			return data.replace(new RegExp(`^.{${indent}}`, "gm"), "");
+		}
+		return data;
+	}
+
 	onTestCaseStarted(data: SourceLocation) {
 		const feature = this.featureMap.get(data.sourceLocation!.uri);
 		if (feature === undefined || feature.feature === undefined) throw new Error("Unknown feature");
@@ -170,7 +181,7 @@ export class CucumberJSAllureFormatter extends Formatter {
 
 		this.currentTest.addLabel(LabelName.FEATURE, feature.feature.name);
 		//this.currentTest.addLabel(LabelName.STORY, feature.feature.name);
-		this.currentTest.description = test.description || "";
+		this.currentTest.description = this.stripIndent(test.description || "");
 		for (const tag of [...(test.tags || []), ...feature.feature.tags]) {
 			this.currentTest.addLabel(LabelName.TAG, tag.name);
 


### PR DESCRIPTION
Previously the description was taken as pre-formatted text due to being indented in Gherkin source, unless you wrote the description without any indentation, which looked weird. This resulted in being unable to wrap your paragraphs in source, and wasn't very nice.