### PR TITLE
fix step keyword and pending status

### DIFF
--- a/src/CucumberJSAllureReporter.ts
+++ b/src/CucumberJSAllureReporter.ts
@@ -188,7 +188,7 @@ export class CucumberJSAllureFormatter extends Formatter {
 		}
 		if (step === undefined) throw new Error("Unknown step");
 
-		let stepText = applyExample(`${step.keyword}${step.text}`, test.example);
+		let stepText = applyExample(`${step.text}`, test.example);
 
 		const isAfter = this.afterHooks.find(({ uri, line }) => {
 			if (location.actionLocation === undefined) return false;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -5,6 +5,7 @@ import { Example } from "./events/Example";
 export function statusTextToAllure(status?: string): Status {
 	if (status === "passed") return Status.PASSED;
 	if (status === "skipped") return Status.SKIPPED;
+	if (status === "pending") return Status.SKIPPED;
 	if (status === "failed") return Status.FAILED;
 	return Status.BROKEN;
 }


### PR DESCRIPTION
I want to suggest two small fixes

1. If we skip the scenario using `return "pending"`, Allure reporter put it to BROKEN scenarios.  
It would be more appropriate to put such scenarios in SKIPPED section.

2. Also, by my opinion, the steps in report of the scenario is more readable without step keyword. What do you think about it?